### PR TITLE
 Updated PlayerSeason to include last 14 day matches 

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -130,7 +130,10 @@ class Client {
     }
 
     /**
-     * Get a player season object. When providing a Player Obj for [player], the PlayerSeason will include the full fetched player in relationships.player. Otherwise, it will just be a reference to the player id and will need .fetch() for its info to be complete.
+     * Get a player season object. 
+     * When providing a Player Obj for [player], the PlayerSeason will include the 
+     * full fetched player in relationships.player. Otherwise, it will just be a 
+     * reference to the player id and will need .fetch() for its info to be complete.
      * @param {(string|Player)} player The player of the player season
      * @param {(string|Season)} season The season of the player season
      * @param {string} [shard=player.attributes.shardId|this.defaultShard] The server shard to send the request to
@@ -158,8 +161,9 @@ class Client {
 
     /**
      * Get an array of up to 10 player season objects.
-     * For PUBG API calls optimization, method will use the regular getPlayerSeason() function when fetching for less than 6 players.
-     * This function is meant to retrieve more than one Player Season. 
+     * For PUBG API calls optimization, method will use the regular 
+     * getPlayerSeason() function when fetching for less than 6 players.
+     * This function is meant to retrieve more than one Player Season.
      * For a single player better use getPlayerSeason()
      * This method will always return fully fetched Player Objects in .relatioships.player
      * @param {Object} args Specify what player to get

--- a/src/Player.js
+++ b/src/Player.js
@@ -17,6 +17,8 @@ class Player {
             return;
         }
 
+        this.full = true;
+
         /**
          * API id of the player
          * @type {string}
@@ -43,22 +45,18 @@ class Player {
             patchVersion: content.attributes.patchVersion,
             titleId: content.attributes.titleId,
         };
-
         /**
          * References to resource objects related to this player
          * @type {Object}
          * @property {Array<Asset>} relationships.assets NOT IN API YET: Array of all assets of the player
          * @property {Array<Match>} relationships.matches Array of empty Match classes, will need `.fetch()`
          */
-        if (content.relationships) {
-            this.relationships = {
-                assets: content.relationships.assets.data,
-                matches: content.relationships.matches.data.map(
-                    m => new Match(m.id, this.client)
-                ),
-            };
-            this.full = true;
-        }
+        this.relationships = {
+            assets: content.relationships.assets.data,
+            matches: content.relationships.matches.data.map(
+                m => new Match(m.id, this.client)
+            ),
+        };
     }
 
     /**

--- a/src/playerseason/PlayerSeason.js
+++ b/src/playerseason/PlayerSeason.js
@@ -9,11 +9,11 @@ const Season = require('../Season');
  */
 class PlayerSeason {
     constructor(content, client) {
-    /**
-     * Attributes of the PlayerSeason
-     * @type {Object}
-     * @property {Object} attributes.gameModeStats An object full of all game mode types being `duo`, `duoFPP`, `solo`, `soloFPP`, `squad`, `squadFPP`
-     */
+        /**
+         * Attributes of the PlayerSeason
+         * @type {Object}
+         * @property {Object} attributes.gameModeStats An object full of all game mode types being `duo`, `duoFPP`, `solo`, `soloFPP`, `squad`, `squadFPP`
+         */
         this.attributes = {
             gameModeStats: {
                 duo: new GameModeStats(content.attributes.gameModeStats.duo),
@@ -42,10 +42,10 @@ class PlayerSeason {
      * @property {Season} relationships.season All solo matches played during the season by the player
      */
         this.relationships = {
-            player:
-        content.relationships.player instanceof Player ?
-            content.relationships.player :
-            new Player(content.relationships.player.data.id, client),
+            player: content.relationships.player instanceof Player ?
+                content.relationships.player :
+                new Player(content.relationships.player.data.id, client),
+
             matchesSolo: content.relationships.matchesSolo.data.map(
                 m => new Match(m.id, this.client)
             ),

--- a/test/index.js
+++ b/test/index.js
@@ -18,6 +18,12 @@ const sampleNames = [
   'PL4sTiKGirL'
 ];
 
+const sampleNames2 = [
+  'Zaytt',
+  'LEYED',
+  'OGSule'
+];
+
 const sampleIds = [
   'account.ce33c4a1f98541068ec656d45b809cfe',
   'account.d6564d57590c4d90b45b0b1d0600df4b',
@@ -34,19 +40,14 @@ const sampleIds = [
 const season = 'division.bro.official.pc-2018-03';
 
 // Test getPlayer
-client.getPlayer({ name: 'Zaytt' }).then(res => console.log(res));
+// client.getPlayer({ name: 'Zaytt' }).then(res => console.log(res));
 
-// Get the player ids and use the result to get their season
-client
-  .getPlayer({ id: playerIds })
-  .then(
-    async p =>
-      await console.log(client.getManyPlayerSeason({ players: p }, season))
-  );
+client.getPlayerSeason('account.c0e530e9b7244b358def282782f893af', season)
+  .then(res => console.log(util.inspect(res, false, null, true /* enable colors */)))
 
 // Straight up search the players season using their names
 client
-  .getManyPlayerSeason({ names: playerNames }, season)
+  .getManyPlayerSeason({ names: sampleNames }, season)
   .then(
     res => console.log(util.inspect(res, false, null, true /* enable colors */))
   )


### PR DESCRIPTION
Recently PUBG updated their API behavior for the Season stats endpoint.
Before they would include all the matches from the past 14 days in matchesSolo, matchesSoloFPP, matchesDuo, matchesDuoFPP, matchesSquad and matchesSquadFPP. But now all of them are capped at 32 matches maximum. This limits the amount of matches info per player that can be obtained.

Meanwhile the Players endpoint retains the old functionality and includes all the player's matches from the past 14 days. So I've decided to include the player's matches in the .player reference in relationships from the PlayerSeason class. 